### PR TITLE
The "Organizing and Managing Open Source Events" page moved

### DIFF
--- a/_data/resources.yml
+++ b/_data/resources.yml
@@ -20,7 +20,7 @@
     - tag: Community Hospitality and Newcomer Experiences
   resources:
     - title: Organizing and Managing Open Source Events
-      url: https://todogroup.org/guides/organizing-and-managing-open-source-events/
+      url: https://todogroup.org/resources/guides/organizing-and-managing-open-source-events/
       type: Read
     - title: Gathering DEI Feedback From Your Open Source Community
       url: https://chaoss.community/gathering-dei-feedback-from-your-open-source-community%ef%bf%bc/


### PR DESCRIPTION
Updated the URL to the correct one!